### PR TITLE
Add Cheminformatics and Metabolomics as BiocViews

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ VignetteBuilder: knitr
 Suggests: BiocStyle, knitr, rmarkdown, testthat
 Description: Use BridgeDb functions and load identifier mapping
         databases in R.
-biocViews: Software, Annotation
+biocViews: Software, Annotation, Metabolomics, Cheminformatics
 License: AGPL-3
 LazyLoad: yes
 URL: https://github.com/bridgedb/BridgeDbR


### PR DESCRIPTION
That way they will show up in http://bioconductor.org/packages/release/BiocViews.html#___Metabolomics
and also in the auto-created docker containers https://hub.docker.com/r/bioconductor/devel_metabolomics2/